### PR TITLE
Add initial header files for CAN, CAN FD and CAN XL

### DIFF
--- a/docs/4_4_1_can.adoc
+++ b/docs/4_4_1_can.adoc
@@ -469,7 +469,7 @@ The required unit for the baudrate value is bit/s.
 |The CAN XL baudrate value to configure.
 The required unit for the baudrate value is bit/s.
 
-.1+|OPTIONS
+|ARBITRATION_LOST_BEHAVIOR
 |Arbitration Lost Behavior
 |1 byte
 |This parameter defines how a Bus Simulation shall behave in cases of an arbitration lost scenario.
@@ -496,7 +496,8 @@ h|Parameter h|Value h|Description
 |CAN_BAUDRATE|0x01|This code indicates that a CAN baud rate should be configured for the Bus Simulation.
 |CAN_FD_BAUDRATE|0x02|Allows the configuration of a CAN FD baudrate for the Bus Simulation.
 |CAN_XL_BAUDRATE|0x03|Allows the configuration of a CAN XL baudrate for the Bus Simulation.
-|OPTIONS|0x04|This code configures various available options for the Bus Simulation.
+|ARBITRATION_LOST_BEHAVIOR|0x04|This code configures the behavior of a Bus Simulation if an arbitration is lost.
+See <<table-can-configuration-arbitration-lost-behavior-kinds>>) for possible values.
 
 |====
 

--- a/docs/headers/fmi3LsBus.h
+++ b/docs/headers/fmi3LsBus.h
@@ -7,8 +7,7 @@ fmi-ls-bus layered standard specification (https://github.com/modelica/fmi-ls-bu
 
 It should be used when creating Network FMUs according to the fmi-ls-bus layered standard.
 
-Copyright (C) 2008-2011 MODELISAR consortium,
-              2012-2023 Modelica Association Project "FMI"
+Copyright (C) 2023 Modelica Association Project "FMI"
               All rights reserved.
 
 This file is licensed by the copyright holders under the 2-Clause BSD License

--- a/docs/headers/fmi3LsBus.h
+++ b/docs/headers/fmi3LsBus.h
@@ -1,0 +1,86 @@
+#ifndef fmi3LsBus_h
+#define fmi3LsBus_h
+
+/*
+This header file declares bus independent constants and data types as defined by the
+fmi-ls-bus layered standard specification (https://github.com/modelica/fmi-ls-bus).
+
+It should be used when creating Network FMUs according to the fmi-ls-bus layered standard.
+
+Copyright (C) 2008-2011 MODELISAR consortium,
+              2012-2023 Modelica Association Project "FMI"
+              All rights reserved.
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
+----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------
+*/
+
+#include "fmi3PlatformTypes.h"
+#include <assert.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * FMI virtual bus operation which indicates an operation format error.
+ */
+#define FMI3_LS_BUS_OP_FORMAT_ERROR ((fmi3LsBusOperationType)0x0001)
+
+/**
+ * Data type for OP codes.
+ */
+typedef fmi3UInt8 fmi3LsBusOperationType;
+
+/**
+ * \brief FMI data type representing the length of payload data.
+ */
+typedef fmi3UInt32 fmi3LsBusOperationLength;
+
+
+#pragma pack(1)
+/**
+ * Operation header data type.
+ */
+typedef struct
+{
+    fmi3LsBusOperationType type; /**< Operation type. */
+    fmi3LsBusOperationLength length; /**< Total length of the operation. */
+} fmi3LsBusOperationHeader;
+
+#pragma pack()
+
+/* Checks the size of 'fmi3LsBusOperationHeader' to make sure the instruction #pragma pack(1) is taken into account  */
+static_assert(sizeof(fmi3LsBusOperationHeader) == 5, "'fmi3LsBusOperationHeader' does not match the expected data size");
+
+#ifdef __cplusplus
+} /* end of extern "C" { */
+#endif
+
+
+#endif /* fmi3LsBus_h */

--- a/docs/headers/fmi3LsBusCan.h
+++ b/docs/headers/fmi3LsBusCan.h
@@ -41,9 +41,19 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "fmi3lsBus.h"
 #include <assert.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /***************************************************
   CAN bus specific OP code 
 ****************************************************/
+        
+/**
+ * Defines the minimum size of a CAN, CAN FD or CAN XL frame.
+ */
+#define MINIMUM_CAN_FRAME_SIZE 1
 
 /**
  * Initiates the transmission of CAN frames.
@@ -128,6 +138,8 @@ typedef fmi3UInt8 fmi3LsBusCanData;
 
 /**
  * Can transmit operation.
+ *
+ * Note: This struct needs to be manually allocated with the size of `sizeof(fmi3LsBusCanOperationCanTransmit) + dataLength - MINIMUM_CAN_FRAME_SIZE`.
  */
 typedef struct
 {
@@ -136,10 +148,10 @@ typedef struct
     fmi3LsBusCanIde ide; /**< Standard (11-bit) or Extended (29-bit) message identifier. */
     fmi3LsBusCanRtr rtr; /**< Remote Transmission Request frame. */
     fmi3LsBusCanDataLength dataLength; /**< Data length. */
-    fmi3LsBusCanData data[]; /**< Data. */
+    fmi3LsBusCanData data[MINIMUM_CAN_FRAME_SIZE]; /**< Data (variable size). */
 } fmi3LsBusCanOperationCanTransmit;
 
-static_assert(sizeof(fmi3LsBusCanOperationCanTransmit) == (5 + 4 + 1 + 1 + 2),
+static_assert(sizeof(fmi3LsBusCanOperationCanTransmit) == (5 + 4 + 1 + 1 + 2 + MINIMUM_CAN_FRAME_SIZE),
               "'fmi3LsBusCanOperationCanTransmit' does not match the expected data size");
 
 /**
@@ -154,6 +166,8 @@ typedef fmi3Boolean fmi3LsBusCanEsi;
 
 /**
  * Can FD transmit operation.
+ *
+ * Note: This struct needs to be manually allocated with the size of `sizeof(fmi3LsBusCanOperationCanFdTransmit) + dataLength - MINIMUM_CAN_FRAME_SIZE`.
  */
 typedef struct
 {
@@ -163,10 +177,10 @@ typedef struct
     fmi3LsBusCanBrs brs;               /**< Bit Rate Switch. */
     fmi3LsBusCanEsi esi;               /**< Error State Idicator. */
     fmi3LsBusCanDataLength dataLength; /**< Data length. */
-    fmi3LsBusCanData data[];           /**< Data. */
+    fmi3LsBusCanData data[MINIMUM_CAN_FRAME_SIZE]; /**< Data (variable size). */
 } fmi3LsBusCanOperationCanFdTransmit;
 
-static_assert(sizeof(fmi3LsBusCanOperationCanFdTransmit) == (5 + 4 + 1 + 1 + 1 + 2),
+static_assert(sizeof(fmi3LsBusCanOperationCanFdTransmit) == (5 + 4 + 1 + 1 + 1 + 2 + MINIMUM_CAN_FRAME_SIZE),
               "'fmi3LsBusCanOperationCanFdTransmit' does not match the expected data size");
 
 /**
@@ -191,6 +205,8 @@ typedef fmi3UInt32 fmi3LsBusCanAf;
 
 /**
  * Can XL transmit operation.
+ *
+ * Note: This struct needs to be manually allocated with the size of `sizeof(fmi3LsBusCanOperationCanXlTransmit) + dataLength - MINIMUM_CAN_FRAME_SIZE`.
  */
 typedef struct
 {
@@ -202,10 +218,10 @@ typedef struct
     fmi3LsBusCanVcId vcid;             /**< Virtual CAN Network ID. */
     fmi3LsBusCanAf af;                 /**< Acceptance Field. */
     fmi3LsBusCanDataLength dataLength; /**< Data length. */
-    fmi3LsBusCanData data[];           /**< Data. */
+    fmi3LsBusCanData data[MINIMUM_CAN_FRAME_SIZE]; /**< Data (variable size).*/
 } fmi3LsBusCanOperationCanXlTransmit;
 
-static_assert(sizeof(fmi3LsBusCanOperationCanXlTransmit) == (5 + 4 + 1 + 1 + 1 + 1 + 4 + 2),
+static_assert(sizeof(fmi3LsBusCanOperationCanXlTransmit) == (5 + 4 + 1 + 1 + 1 + 1 + 4 + 2 + MINIMUM_CAN_FRAME_SIZE),
               "'fmi3LsBusCanOperationCanXlTransmit' does not match the expected data size");
 
 /**

--- a/docs/headers/fmi3LsBusCan.h
+++ b/docs/headers/fmi3LsBusCan.h
@@ -146,12 +146,12 @@ static_assert(sizeof(fmi3LsBusCanOperationCanTransmit) == (5 + 4 + 1 + 1 + 2),
 /**
  * Data type for defining a Bit Rate Switch.
  */
-typedef fmi3UInt8 fmi3LsBusCanBrs;
+typedef fmi3Boolean fmi3LsBusCanBrs;
 
 /**
  * Data type for defining a Error State Indicator.
  */
-typedef fmi3UInt8 fmi3LsBusCanEsi;
+typedef fmi3Boolean fmi3LsBusCanEsi;
 
 /**
  * Can FD transmit operation.
@@ -173,7 +173,7 @@ static_assert(sizeof(fmi3LsBusCanOperationCanFdTransmit) == (5 + 4 + 1 + 1 + 1 +
 /**
  * Data type for defining a Simple Extended Content.
  */
-typedef fmi3UInt8 fmi3LsBusCanSec;
+typedef fmi3Boolean fmi3LsBusCanSec;
 
 /**
  * Data type for defining a Service Data Unit Type.
@@ -325,7 +325,7 @@ typedef fmi3UInt8 fmi3LsBusCanConfigParameterType;
 #define FMI3_LS_BUS_CAN_CONFIG_PARAM_TYPE_CAN_BAUDRATE ((fmi3LsBusCanConfigParameterType)0x1)
 #define FMI3_LS_BUS_CAN_CONFIG_PARAM_TYPE_CANFD_BAUDRATE ((fmi3LsBusCanConfigParameterType)0x2)
 #define FMI3_LS_BUS_CAN_CONFIG_PARAM_TYPE_CANXL_BAUDRATE ((fmi3LsBusCanConfigParameterType)0x3)
-#define FMI3_LS_BUS_CAN_CONFIG_PARAM_TYPE_OPTIONS ((fmi3LsBusCanConfigParameterType)0x4)
+#define FMI3_LS_BUS_CAN_CONFIG_PARAM_TYPE_ARBITRATION_LOST_BEHAVIOR ((fmi3LsBusCanConfigParameterType)0x4)
 
 /**
  * FMI data type to be used for the CAN configuration options.

--- a/docs/headers/fmi3LsBusCan.h
+++ b/docs/headers/fmi3LsBusCan.h
@@ -1,0 +1,376 @@
+#ifndef fmi3LsBusCan_h
+#define fmi3LsBusCan_h
+
+/*
+This header file declares CAN bus specific constants and data types as defined by the
+fmi-ls-bus layered standard specification (https://github.com/modelica/fmi-ls-bus).
+
+It should be used when creating CAN Network FMUs according to the fmi-ls-bus layered standard.
+
+Copyright (C) 2008-2011 MODELISAR consortium,
+              2012-2023 Modelica Association Project "FMI"
+              All rights reserved.
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
+----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------
+*/
+
+#include "fmi3lsBus.h"
+#include <assert.h>
+
+/***************************************************
+  CAN bus specific OP code 
+****************************************************/
+
+/**
+ * Initiates the transmission of CAN frames.
+ */
+#define FMI3_LS_BUS_CAN_OP_CAN_TRANSMIT ((fmi3LsBusOperationType)0x0010)
+
+/**
+ * Represents an operation for the transmission of a CAN FD frame.
+ */
+#define FMI3_LS_BUS_CAN_OP_CANFD_TRANSMIT ((fmi3LsBusOperationType)0x0011)
+
+/**
+ * Represents an operation for the transmission of a CAN XL frame.
+ */
+#define FMI3_LS_BUS_CAN_OP_CANXL_TRANSMIT ((fmi3LsBusOperationType)0x0012)
+
+/**
+ * Signals successful receipt of a transmitted CAN, CAN FD and CAN XL frame to simulate a CAN acknowledgment behavior.
+ */
+#define FMI3_LS_BUS_CAN_OP_CONFIRM ((fmi3LsBusOperationType)0x0020)
+
+/**
+ * The Arbitration Lost operation indicates that a CAN frame could not be sent immediately and was therefore
+ * discarded by the Bus Simulation.
+ */
+#define FMI3_LS_BUS_CAN_OP_ARBITRATION_LOST ((fmi3LsBusOperationType)0x0030)
+
+/**
+ * Represents an operation for simulated bus errors.
+ */
+#define FMI3_LS_BUS_CAN_OP_CAN_BUS_ERROR ((fmi3LsBusOperationType)0x0031)
+
+/**
+ * Represents an operation for the configuration of a Bus Simulation. In detail, the configuration of a CAN, CAN FD
+ * and CAN XL baud rate is possible. Also the configuration of further options, like buffer handling, is supported
+ * by this operation.
+ */
+#define FMI3_LS_BUS_CAN_OP_CONFIGURATION ((fmi3LsBusOperationType)0x0040)
+
+/**
+ * FMI virtual bus operation which indicates a status operation.
+ */
+#define FMI3_LS_BUS_CAN_OP_STATUS ((fmi3LsBusOperationType)0x0041)
+
+/**
+ * Represents an operation for triggering a bus-specific wake up.
+ */
+#define FMI3_LS_BUS_CAN_OP_WAKEUP ((fmi3LsBusOperationType)0x0042)
+
+
+
+/***************************************************
+Types for CAN specific bus operations
+****************************************************/
+
+#pragma pack(1)
+
+/**
+ * Data type representing the CAN identifer.
+ */
+typedef fmi3UInt32 fmi3LsBusCanId;
+
+/**
+ * Data type for defining a standard or extended messages.
+ */
+typedef fmi3Boolean fmi3LsBusCanIde;
+
+/**
+ * Data type for defining a Remote Transmission Request frame.
+ */
+typedef fmi3Boolean fmi3LsBusCanRtr;
+
+/**
+ * Data type for data length.
+ */
+typedef fmi3UInt16 fmi3LsBusCanDataLength;
+
+/**
+ * Data type for data.
+ */
+typedef fmi3UInt8 fmi3LsBusCanData;
+
+/**
+ * Can transmit operation.
+ */
+typedef struct
+{
+    fmi3LsBusOperationHeader header; /**< Message header */
+    fmi3LsBusCanId  id; /**<  CAN message ID. */
+    fmi3LsBusCanIde ide; /**< Standard (11-bit) or Extended (29-bit) message identifier. */
+    fmi3LsBusCanRtr rtr; /**< Remote Transmission Request frame. */
+    fmi3LsBusCanDataLength dataLength; /**< Data length. */
+    fmi3LsBusCanData data[]; /**< Data. */
+} fmi3LsBusCanOperationCanTransmit;
+
+static_assert(sizeof(fmi3LsBusCanOperationCanTransmit) == (5 + 4 + 1 + 1 + 2),
+              "'fmi3LsBusCanOperationCanTransmit' does not match the expected data size");
+
+/**
+ * Data type for defining a Bit Rate Switch.
+ */
+typedef fmi3UInt8 fmi3LsBusCanBrs;
+
+/**
+ * Data type for defining a Error State Indicator.
+ */
+typedef fmi3UInt8 fmi3LsBusCanEsi;
+
+/**
+ * Can FD transmit operation.
+ */
+typedef struct
+{
+    fmi3LsBusOperationHeader header;   /**< Message header */
+    fmi3LsBusCanId id;                 /**<  CAN message ID. */
+    fmi3LsBusCanIde ide;               /**< Standard (11-bit) or Extended (29-bit) message identifier. */
+    fmi3LsBusCanBrs brs;               /**< Bit Rate Switch. */
+    fmi3LsBusCanEsi esi;               /**< Error State Idicator. */
+    fmi3LsBusCanDataLength dataLength; /**< Data length. */
+    fmi3LsBusCanData data[];           /**< Data. */
+} fmi3LsBusCanOperationCanFdTransmit;
+
+static_assert(sizeof(fmi3LsBusCanOperationCanFdTransmit) == (5 + 4 + 1 + 1 + 1 + 2),
+              "'fmi3LsBusCanOperationCanFdTransmit' does not match the expected data size");
+
+/**
+ * Data type for defining a Simple Extended Content.
+ */
+typedef fmi3UInt8 fmi3LsBusCanSec;
+
+/**
+ * Data type for defining a Service Data Unit Type.
+ */
+typedef fmi3UInt8 fmi3LsBusCanSdt;
+
+/**
+ * Data type for defining a Virtual CAN Network ID.
+ */
+typedef fmi3UInt8 fmi3LsBusCanVcId;
+
+/**
+ * Data type for defining an Acceptance Field.
+ */
+typedef fmi3UInt32 fmi3LsBusCanAf;
+
+/**
+ * Can XL transmit operation.
+ */
+typedef struct
+{
+    fmi3LsBusOperationHeader header;   /**< Message header */
+    fmi3LsBusCanId id;                 /**<  CAN message ID. */
+    fmi3LsBusCanIde ide;               /**< Standard (11-bit) or Extended (29-bit) message identifier. */
+    fmi3LsBusCanSec sec;               /**< Simple Extended Content. */
+    fmi3LsBusCanSdt sdt;               /**< Service Data Unit Type. */
+    fmi3LsBusCanVcId vcid;             /**< Virtual CAN Network ID. */
+    fmi3LsBusCanAf af;                 /**< Acceptance Field. */
+    fmi3LsBusCanDataLength dataLength; /**< Data length. */
+    fmi3LsBusCanData data[];           /**< Data. */
+} fmi3LsBusCanOperationCanXlTransmit;
+
+static_assert(sizeof(fmi3LsBusCanOperationCanXlTransmit) == (5 + 4 + 1 + 1 + 1 + 1 + 4 + 2),
+              "'fmi3LsBusCanOperationCanXlTransmit' does not match the expected data size");
+
+/**
+ * Can confirm operation.
+ */
+typedef struct
+{
+    fmi3LsBusOperationHeader header; /**< Message header */
+    fmi3LsBusCanId id; /**<  CAN message ID. */
+} fmi3LsBusCanOperationConfirm;
+
+static_assert(sizeof(fmi3LsBusCanOperationConfirm) == (5 + 4),
+              "'fmi3LsBusCanOperationConfirm' does not match the expected data size");
+
+/**
+ * Can arbitration lost operation.
+ */
+typedef struct
+{
+    fmi3LsBusOperationHeader header; /**< Message header */
+    fmi3LsBusCanId id;               /**<  CAN message ID. */
+} fmi3LsBusCanOperationArbitrationLost;
+
+static_assert(sizeof(fmi3LsBusCanOperationArbitrationLost) == (5 + 4),
+              "'fmi3LsBusCanOperationArbitrationLost' does not match the expected data size");
+
+/**
+ * FMI data type to be used for the CAN bus error code.
+ */
+typedef fmi3UInt8 fmi3LsBusCanErrorCode;
+
+#define FMI3_LS_BUS_CAN_BUSERROR_PARAM_ERROR_CODE_BIT_ERROR \
+    ((fmi3LsBusCanErrorCode)0x1)
+
+#define FMI3_LS_BUS_CAN_BUSERROR_PARAM_ERROR_CODE_BIT_STUFFING_ERROR \
+    ((fmi3LsBusCanErrorCode)0x2)
+
+#define FMI3_LS_BUS_CAN_BUSERROR_PARAM_ERROR_CODE_FORM_ERROR \
+    ((fmi3LsBusCanErrorCode)0x3)
+
+#define FMI3_LS_BUS_CAN_BUSERROR_PARAM_ERROR_CODE_CRC_ERROR \
+    ((fmi3LsBusCanErrorCode)0x4)
+
+#define FMI3_LS_BUS_CAN_BUSERROR_PARAM_ERROR_CODE_ACK_ERROR \
+    ((fmi3LsBusCanErrorCode)0x5)
+
+#define FMI3_LS_BUS_CAN_BUSERROR_PARAM_ERROR_CODE_BROKEN_ERROR_FRAME \
+    ((fmi3LsBusCanErrorCode)0x6)
+
+/**
+ * FMI data type to be used for the CAN bus error flag.
+ */
+typedef fmi3UInt8 fmi3LsBusCanErrorFlag;
+
+#define FMI3_LS_BUS_CAN_BUSERROR_PARAM_ERROR_FLAG_PRIMARY_ERROR_FLAG ((fmi3LsBusCanErrorFlag)0x1)
+
+#define FMI3_LS_BUS_CAN_BUSERROR_PARAM_ERROR_FLAG_SECONDARY_ERROR_FLAG ((fmi3LsBusCanErrorFlag)0x2)
+
+/**
+ * Data type for defining a sender or receiver situation.
+ */
+typedef fmi3Boolean fmi3LsBusCanIsSender;
+
+/**
+ * Can bus error operation.
+ */
+typedef struct
+{
+    fmi3LsBusOperationHeader header; /**< Message header */
+    fmi3LsBusCanId id;               /**<  CAN message ID. */
+    fmi3LsBusCanErrorCode errorCode; /**<  Bus Error Code. */
+    fmi3LsBusCanErrorFlag errorFlag; /**<  Bus Error Flag. */
+    fmi3LsBusCanIsSender isSender;   /**<  Is Sender. */
+} fmi3LsBusCanOperationBusError;
+
+static_assert(sizeof(fmi3LsBusCanOperationBusError) == (5 + 4 + 1 + 1 + 1),
+              "'fmi3LsBusCanOperationBusError' does not match the expected data size");
+
+/**
+ * FMI data type to be used for the CAN status kind.
+ */
+typedef fmi3UInt8 fmi3LsBusCanStatusKind;
+
+#define FMI3_LS_BUS_CAN_STATUS_PARAM_STATUS_KIND_ERROR_ACTIVE ((fmi3LsBusCanStatusKind)0x1)
+
+#define FMI3_LS_BUS_CAN_STATUS_PARAM_STATUS_KIND_ERROR_PASSIVE ((fmi3LsBusCanStatusKind)0x2)
+
+#define FMI3_LS_BUS_CAN_STATUS_PARAM_STATUS_KIND_BUS_OFF ((fmi3LsBusCanStatusKind)0x3)
+
+/**
+ * Can status operation.
+ */
+typedef struct
+{
+    fmi3LsBusOperationHeader header; /**< Message header */
+    fmi3LsBusCanId id;               /**<  CAN message ID. */
+    fmi3LsBusCanStatusKind status;   /**<  Status Kind. */
+} fmi3LsBusCanOperationStatus;
+
+static_assert(sizeof(fmi3LsBusCanOperationStatus) == (5 + 4 + 1),
+              "'fmi3LsBusCanOperationStatus' does not match the expected data size");
+
+/**
+ * FMI data type to be used for baudrate settings.
+ */
+typedef fmi3UInt32 fmi3LsBusCanBaudrate;
+
+/**
+ * FMI data type to be used for the configuration parameter type.
+ */
+typedef fmi3UInt8 fmi3LsBusCanConfigParameterType;
+
+/**
+ * Definitions of configuration parameter type.
+ */
+#define FMI3_LS_BUS_CAN_CONFIG_PARAM_TYPE_CAN_BAUDRATE ((fmi3LsBusCanConfigParameterType)0x1)
+#define FMI3_LS_BUS_CAN_CONFIG_PARAM_TYPE_CANFD_BAUDRATE ((fmi3LsBusCanConfigParameterType)0x2)
+#define FMI3_LS_BUS_CAN_CONFIG_PARAM_TYPE_CANXL_BAUDRATE ((fmi3LsBusCanConfigParameterType)0x3)
+#define FMI3_LS_BUS_CAN_CONFIG_PARAM_TYPE_OPTIONS ((fmi3LsBusCanConfigParameterType)0x4)
+
+/**
+ * FMI data type to be used for the CAN configuration options.
+ */
+typedef fmi3UInt8 fmi3LsBusCanArbitrationLostBehavior;
+
+#define FMI3_LS_BUS_CAN_CONFIG_PARAM_ARBITRATION_LOST_BEHAVIOR_BUFFER_AND_RETRANSMIT \
+    ((fmi3LsBusCanArbitrationLostBehavior)0x1)
+
+#define FMI3_LS_BUS_CAN_CONFIG_PARAM_ARBITRATION_LOST_BEHAVIOR_DISCARD_AND_NOTIFY \
+    ((fmi3LsBusCanArbitrationLostBehavior)0x2)
+
+/**
+ * Can configuration operation.
+ */
+typedef struct
+{
+    fmi3LsBusOperationHeader header; /**< Message header */
+    fmi3LsBusCanConfigParameterType parameterType; /**< Defines the current configuration parameter.
+                                                        Note: Only one parameter can be set per Configuration operation. */
+    union
+    {
+        fmi3LsBusCanBaudrate baudrate;
+        fmi3LsBusCanArbitrationLostBehavior arbitrationLostBehavior;
+    };
+} fmi3LsBusOperationCanConfiguration;
+
+static_assert(sizeof(fmi3LsBusOperationCanConfiguration) >= (5 + 4 + 1),
+              "'fmi3LsBusOperationCanConfiguration' does not match the expected data size");
+
+/**
+ * Can wakeup operation.
+ */
+typedef struct
+{
+    fmi3LsBusOperationHeader header; /**< Message header */
+} fmi3LsBusCanOperationWakeup;
+
+static_assert(sizeof(fmi3LsBusCanOperationWakeup) == (5),
+              "'fmi3LsBusCanOperationWakeup' does not match the expected data size");
+
+#pragma pack()
+
+#ifdef __cplusplus
+} /* end of extern "C" { */
+#endif
+
+#endif /* fmi3LsBusCan_h */

--- a/docs/headers/fmi3LsBusCan.h
+++ b/docs/headers/fmi3LsBusCan.h
@@ -7,8 +7,7 @@ fmi-ls-bus layered standard specification (https://github.com/modelica/fmi-ls-bu
 
 It should be used when creating CAN Network FMUs according to the fmi-ls-bus layered standard.
 
-Copyright (C) 2008-2011 MODELISAR consortium,
-              2012-2023 Modelica Association Project "FMI"
+Copyright (C) 2023 Modelica Association Project "FMI"
               All rights reserved.
 
 This file is licensed by the copyright holders under the 2-Clause BSD License

--- a/docs/headers/fmi3LsBusCan.h
+++ b/docs/headers/fmi3LsBusCan.h
@@ -41,6 +41,11 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "fmi3lsBus.h"
 #include <assert.h>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4200)
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -49,11 +54,6 @@ extern "C"
 /***************************************************
   CAN bus specific OP code 
 ****************************************************/
-        
-/**
- * Defines the minimum size of a CAN, CAN FD or CAN XL frame.
- */
-#define MINIMUM_CAN_FRAME_SIZE 1
 
 /**
  * Initiates the transmission of CAN frames.
@@ -119,12 +119,12 @@ typedef fmi3UInt32 fmi3LsBusCanId;
 /**
  * Data type for defining a standard or extended messages.
  */
-typedef fmi3Boolean fmi3LsBusCanIde;
+typedef fmi3UInt8 fmi3LsBusCanIde;
 
 /**
  * Data type for defining a Remote Transmission Request frame.
  */
-typedef fmi3Boolean fmi3LsBusCanRtr;
+typedef fmi3UInt8 fmi3LsBusCanRtr;
 
 /**
  * Data type for data length.
@@ -138,8 +138,6 @@ typedef fmi3UInt8 fmi3LsBusCanData;
 
 /**
  * Can transmit operation.
- *
- * Note: This struct needs to be manually allocated with the size of `sizeof(fmi3LsBusCanOperationCanTransmit) + dataLength - MINIMUM_CAN_FRAME_SIZE`.
  */
 typedef struct
 {
@@ -148,26 +146,24 @@ typedef struct
     fmi3LsBusCanIde ide; /**< Standard (11-bit) or Extended (29-bit) message identifier. */
     fmi3LsBusCanRtr rtr; /**< Remote Transmission Request frame. */
     fmi3LsBusCanDataLength dataLength; /**< Data length. */
-    fmi3LsBusCanData data[MINIMUM_CAN_FRAME_SIZE]; /**< Data (variable size). */
+    fmi3LsBusCanData data[]; /**< Data. */
 } fmi3LsBusCanOperationCanTransmit;
 
-static_assert(sizeof(fmi3LsBusCanOperationCanTransmit) == (5 + 4 + 1 + 1 + 2 + MINIMUM_CAN_FRAME_SIZE),
+static_assert(sizeof(fmi3LsBusCanOperationCanTransmit) == (5 + 4 + 1 + 1 + 2),
               "'fmi3LsBusCanOperationCanTransmit' does not match the expected data size");
 
 /**
  * Data type for defining a Bit Rate Switch.
  */
-typedef fmi3Boolean fmi3LsBusCanBrs;
+typedef fmi3UInt8 fmi3LsBusCanBrs;
 
 /**
  * Data type for defining a Error State Indicator.
  */
-typedef fmi3Boolean fmi3LsBusCanEsi;
+typedef fmi3UInt8 fmi3LsBusCanEsi;
 
 /**
  * Can FD transmit operation.
- *
- * Note: This struct needs to be manually allocated with the size of `sizeof(fmi3LsBusCanOperationCanFdTransmit) + dataLength - MINIMUM_CAN_FRAME_SIZE`.
  */
 typedef struct
 {
@@ -177,16 +173,16 @@ typedef struct
     fmi3LsBusCanBrs brs;               /**< Bit Rate Switch. */
     fmi3LsBusCanEsi esi;               /**< Error State Idicator. */
     fmi3LsBusCanDataLength dataLength; /**< Data length. */
-    fmi3LsBusCanData data[MINIMUM_CAN_FRAME_SIZE]; /**< Data (variable size). */
+    fmi3LsBusCanData data[]; /**< Data. */
 } fmi3LsBusCanOperationCanFdTransmit;
 
-static_assert(sizeof(fmi3LsBusCanOperationCanFdTransmit) == (5 + 4 + 1 + 1 + 1 + 2 + MINIMUM_CAN_FRAME_SIZE),
+static_assert(sizeof(fmi3LsBusCanOperationCanFdTransmit) == (5 + 4 + 1 + 1 + 1 + 2),
               "'fmi3LsBusCanOperationCanFdTransmit' does not match the expected data size");
 
 /**
  * Data type for defining a Simple Extended Content.
  */
-typedef fmi3Boolean fmi3LsBusCanSec;
+typedef fmi3UInt8 fmi3LsBusCanSec;
 
 /**
  * Data type for defining a Service Data Unit Type.
@@ -205,8 +201,6 @@ typedef fmi3UInt32 fmi3LsBusCanAf;
 
 /**
  * Can XL transmit operation.
- *
- * Note: This struct needs to be manually allocated with the size of `sizeof(fmi3LsBusCanOperationCanXlTransmit) + dataLength - MINIMUM_CAN_FRAME_SIZE`.
  */
 typedef struct
 {
@@ -218,10 +212,10 @@ typedef struct
     fmi3LsBusCanVcId vcid;             /**< Virtual CAN Network ID. */
     fmi3LsBusCanAf af;                 /**< Acceptance Field. */
     fmi3LsBusCanDataLength dataLength; /**< Data length. */
-    fmi3LsBusCanData data[MINIMUM_CAN_FRAME_SIZE]; /**< Data (variable size).*/
+    fmi3LsBusCanData data[]; /**< Data.*/
 } fmi3LsBusCanOperationCanXlTransmit;
 
-static_assert(sizeof(fmi3LsBusCanOperationCanXlTransmit) == (5 + 4 + 1 + 1 + 1 + 1 + 4 + 2 + MINIMUM_CAN_FRAME_SIZE),
+static_assert(sizeof(fmi3LsBusCanOperationCanXlTransmit) == (5 + 4 + 1 + 1 + 1 + 1 + 4 + 2),
               "'fmi3LsBusCanOperationCanXlTransmit' does not match the expected data size");
 
 /**
@@ -283,7 +277,7 @@ typedef fmi3UInt8 fmi3LsBusCanErrorFlag;
 /**
  * Data type for defining a sender or receiver situation.
  */
-typedef fmi3Boolean fmi3LsBusCanIsSender;
+typedef fmi3UInt8 fmi3LsBusCanIsSender;
 
 /**
  * Can bus error operation.
@@ -386,6 +380,10 @@ static_assert(sizeof(fmi3LsBusCanOperationWakeup) == (5),
 
 #ifdef __cplusplus
 } /* end of extern "C" { */
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(pop)
 #endif
 
 #endif /* fmi3LsBusCan_h */


### PR DESCRIPTION
Initial header files for CAN, CAN FD and CAN XL; ready for discussion. Also review the utility headers of the fmi-ls-bus which you find at https://github.com/modelica/fmi-guides/pull/82. The utility headers contains additional functionality to build operations more easy. 