### PR TITLE
Use memberName instead of naming conv for clock in high-cut

### DIFF
--- a/docs/3____physical_signal_abstraction.adoc
+++ b/docs/3____physical_signal_abstraction.adoc
@@ -100,7 +100,7 @@ Element definitions::
  * There must be no `<TerminalStreamMemberVariable>` element.
  * There must be one <<high-cut-pdu-terminal>> element per PDU of this frame.
  * There must be one `<TerminalMemberVariable>` for the Clock this frame is connected to.
-   The name of this variable is composed as <<high-cut-clock-variables,`BusName.FrameName_Clock`>>, e.g., `Powertrain.tcuSensors_Clock`.
+   The `memberName` of this variable must be "Clock".
 
 The <<high-cut-terminal-member-variable-for-signals>> must have the same `causality` as all variables referenced in the <<high-cut-pdu-terminal,PDU Terminals>> included here.
 

--- a/docs/examples/X_network4FMI_terminalsAndIcons_highCut.xml
+++ b/docs/examples/X_network4FMI_terminalsAndIcons_highCut.xml
@@ -5,7 +5,7 @@
         description="Powertrain CAN bus defined with dbc file">
       <Terminal terminalKind="org.fmi-ls-bus.frame-terminal" name="tcuSensors" matchingRule="bus">
         <TerminalMemberVariable variableKind="signal"
-          variableName="Powertrain.tcuSensors_Clock" />
+          variableName="Powertrain.tcuSensors_Clock" memberName="Clock" />
         <Terminal terminalKind="org.fmi-ls-bus.pdu-terminal" name="tcuSensors" matchingRule="bus">
           <TerminalMemberVariable variableKind="signal"
             variableName="Powertrain.tcuSensors.tcuSensors.vCar" memberName="vCar" />
@@ -15,7 +15,7 @@
       </Terminal>
       <Terminal terminalKind="org.fmi-ls-bus.frame-terminal" name="tcuState" matchingRule="bus">
         <TerminalMemberVariable variableKind="signal"
-          variableName="Powertrain.tcuState_Clock" />
+          variableName="Powertrain.tcuState_Clock" memberName="Clock" />
         <Terminal terminalKind="org.fmi-ls-bus.pdu-terminal" name="tcuState" matchingRule="bus">
           <TerminalMemberVariable variableKind="signal"
             variableName="Powertrain.tcuState.tcuState.state" memberName="state" />
@@ -27,7 +27,7 @@
       </Terminal>
       <Terminal terminalKind="org.fmi-ls-bus.frame-terminal" name="ecuState" matchingRule="bus">
         <TerminalMemberVariable variableKind="signal"
-          variableName="Powertrain.ecuState_Clock" />
+          variableName="Powertrain.ecuState_Clock" memberName="Clock" />
         <Terminal terminalKind="org.fmi-ls-bus.pdu-terminal" name="ecuState" matchingRule="bus">
           <TerminalMemberVariable variableKind="signal"
             variableName="Powertrain.ecuState.ecuState.accelPedal" memberName="accelPedal" />


### PR DESCRIPTION
fixes #188