### PR TITLE
Add initial contributors list

### DIFF
--- a/docs/5____additional_content.adoc
+++ b/docs/5____additional_content.adoc
@@ -3,6 +3,7 @@
 - Christian Bertsch, Robert Bosch GmbH, Germany
 - Clemens Boos, dSPACE GmbH, Germany
 - Martin Engel, dSPACE GmbH, Germany
+- Nikolai Fast, Beckhoff Automation GmbH & Co. KG, Germany
 - Andreas Junghanns, Synopsys, Germany
 - Kahramon Jumayev, Akkodis, Germany
 - Pierre R. Mai, PMSF IT Consulting, Germany

--- a/docs/5____additional_content.adoc
+++ b/docs/5____additional_content.adoc
@@ -10,6 +10,7 @@
 - Klaus Schuch, AVL List GmbH, Austria
 - Markus S&#252;vern, dSPACE GmbH, Germany
 - Tim Pfitzer, Robert Bosch GmbH, Germany 
+- Sonja Pusch, dSPACE GmbH, Germany
 - Patrick T&#228;uber, dSPACE GmbH, Germany
 - ...
 

--- a/docs/5____additional_content.adoc
+++ b/docs/5____additional_content.adoc
@@ -1,6 +1,16 @@
 == Contributions
-#TODO: Add contributions here#
 
+- Christian Bertsch, Robert Bosch GmbH, Germany
+- Clemens Boos, dSPACE GmbH, Germany
+- Martin Engel, dSPACE GmbH, Germany
+- Andreas Junghanns, Synopsys, Germany
+- Pierre R. Mai, PMSF IT Consulting, Germany
+- Benedikt Menne, dSPACE GmbH, Germany
+- Jan Ribbe, Synopsys, Germany
+- Klaus Schuch, AVL List GmbH, Austria
+- Markus S&#252;vern, dSPACE GmbH, Germany
+- Tim Pfitzer, Robert Bosch GmbH, Germany 
+- Patrick T&#228;uber, dSPACE GmbH, Germany
 - ...
 
 Contributions to this layered standard to the FMI standard are covered by the https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf[Corporate Contributors License Agreement (CCLA)] of the Modelica Association Project FMI.

--- a/docs/5____additional_content.adoc
+++ b/docs/5____additional_content.adoc
@@ -4,6 +4,7 @@
 - Clemens Boos, dSPACE GmbH, Germany
 - Martin Engel, dSPACE GmbH, Germany
 - Andreas Junghanns, Synopsys, Germany
+- Kahramon Jumayev, Akkodis, Germany
 - Pierre R. Mai, PMSF IT Consulting, Germany
 - Benedikt Menne, dSPACE GmbH, Germany
 - Jan Ribbe, Synopsys, Germany

--- a/docs/5____additional_content.adoc
+++ b/docs/5____additional_content.adoc
@@ -13,7 +13,6 @@
 - Sonja Pusch, dSPACE GmbH, Germany
 - Patrick T&#228;uber, dSPACE GmbH, Germany
 - Ella Vahle, dSPACE GmbH, Germany
-- ...
 
 Contributions to this layered standard to the FMI standard are covered by the https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf[Corporate Contributors License Agreement (CCLA)] of the Modelica Association Project FMI.
 

--- a/docs/5____additional_content.adoc
+++ b/docs/5____additional_content.adoc
@@ -12,6 +12,7 @@
 - Tim Pfitzer, Robert Bosch GmbH, Germany 
 - Sonja Pusch, dSPACE GmbH, Germany
 - Patrick T&#228;uber, dSPACE GmbH, Germany
+- Ella Vahle, dSPACE GmbH, Germany
 - ...
 
 Contributions to this layered standard to the FMI standard are covered by the https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf[Corporate Contributors License Agreement (CCLA)] of the Modelica Association Project FMI.


### PR DESCRIPTION
@chrbertsch I started filling the contributors list of the fmi-ls-bus. **This is a not complete list**. Maybe we can ask within the next Design Meetings who is missing on the list and add the rest via that PR. I also think that we can successively maintain this list. I just want to start it, because of the ToDo within the specified fmi-ls-bus chapter. 