### PR TITLE
Fixed too short NIT Length argument size within FlexRay Configuration operation

### DIFF
--- a/docs/4_4_3_flexray.adoc
+++ b/docs/4_4_3_flexray.adoc
@@ -498,7 +498,7 @@ See `gdSymbolWindowActionPointOffset` parameter within FlexRay specification for
 See `gdSymbolWindow` parameter within FlexRay specification for further information.
 
 |NIT Length
-|1 byte
+|2 bytes
 |Specifies the length of the Network Idle Time in macroticks.
 See `gdNIT` parameter within FlexRay specification for further information.
 

--- a/headers/fmi3LsBusFlexRay.h
+++ b/headers/fmi3LsBusFlexRay.h
@@ -469,14 +469,14 @@ typedef struct
     fmi3LsBusFlexRayDurationMt8 minislotLength;             /**< The length of a minislot in the dynamic segment in macroticks. */
     fmi3LsBusFlexRayDurationMt8 symbolActionPointOffset;    /**< The action point offset of a symbol window in macroticks. */
     fmi3LsBusFlexRayDurationMt8 symbolWindowLength;         /**< The length of the symbol window in macroticks. */
-    fmi3LsBusFlexRayDurationMt8 nitLength;                  /**< The length of the NIT in macroticks. */
+    fmi3LsBusFlexRayDurationMt16 nitLength;                 /**< The length of the NIT in macroticks. */
     NetworkManagementVectorLength nmVectorLength;           /**< The length of the Network Management Vector. */
     fmi3LsBusFlexRayDurationMt32 dynamicSlotIdleTime;       /**< The length of dynamic slot idle time within a dynamic segment in macroticks. */  
     fmi3LsBusFlexRayColdstartNodeType coldstartNode;        /**< Specifies the coldstart capabilities of a FlexRay node. */
 } fmi3LsBusFlexRayConfigurationFlexRayConfig;
 
 #if FMI3_LS_BUS_CHECK_OPERATION_SIZE == 1
-static_assert(sizeof(fmi3LsBusFlexRayConfigurationFlexRayConfig) == (4 + 2 + 1 + 1 + 1 + 2 + 2 + 1 + 1 + 2 + 1 + 1 + 1 + 1 + 4 + 1),
+static_assert(sizeof(fmi3LsBusFlexRayConfigurationFlexRayConfig) == (4 + 2 + 1 + 1 + 1 + 2 + 2 + 1 + 1 + 2 + 1 + 1 + 2 + 1 + 4 + 1),
               "'fmi3LsBusFlexRayConfigurationFlexRayConfig' does not match the expected data size");
 #endif
 

--- a/headers/fmi3LsBusUtilFlexRay.h
+++ b/headers/fmi3LsBusUtilFlexRay.h
@@ -207,7 +207,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         _op.header.length = sizeof(fmi3LsBusOperationHeader) +                         \
             sizeof(fmi3LsBusFlexRayConfigParameterType) +                              \
             sizeof(fmi3LsBusFlexRayConfigurationFlexRayConfig);                        \
-        _op.parameterType = FMI3_LS_BUS_FLEXRAY_CONFIG_PARAM_TYPE_FLEXRAY_CONFIG;  \
+        _op.parameterType = FMI3_LS_BUS_FLEXRAY_CONFIG_PARAM_TYPE_FLEXRAY_CONFIG;      \
         _op.flexRayConfig.macrotickDuration = (MacrotickDuration);                     \
         _op.flexRayConfig.macroticksPerCycle = (MacroticksPerCycle);                   \
         _op.flexRayConfig.cycleCountMax = (CycleCountMax);                             \


### PR DESCRIPTION
The NIT Length argument size of FlexRay Configuration operation is currently one byte long. Because the maximum value is 15978, an argument size of two bytes is required