### PR TITLE
Homogenization of the system composition names

### DIFF
--- a/docs/1____introduction.adoc
+++ b/docs/1____introduction.adoc
@@ -26,7 +26,7 @@ The importer only needs to support FMI variables, Clocks, and terminals, which a
 * Composition with dedicated Bus Simulation FMU: A separate Bus Simulation FMU is used to simulate the specific bus behavior.
 Other FMUs that want to emulate bus communication provide and relate network information via this Bus Simulation FMU.
 This communication architecture can be operated by a common FMU importer and allows complex and detailed bus simulations.
-* Importer with Integrated Bus Simulation: Works analogously to the Composition with dedicated Bus Simulation FMU architecture, whereby the Bus Simulation FMU is directly integrated into an importer or other simulator.
+* Importer with integrated Bus Simulation: Works analogously to the Composition with dedicated Bus Simulation FMU architecture, whereby the Bus Simulation FMU is directly integrated into an importer or other simulator.
 
 === System Simulation Effects [[introduction-system-simulation-effects]]
 

--- a/docs/2____common_concepts.adoc
+++ b/docs/2____common_concepts.adoc
@@ -80,7 +80,7 @@ This communication architecture enables complex bus simulations to be implemente
 An n:m bus communication of several FMUs is also permitted.
 Depending on the needs, it may be necessary to dynamically provision the Bus Simulation FMU so that it provides the appropriate number of inputs and outputs to allow all FMUs to be connected.
 
-==== Importer with Integrated Bus Simulation [[common-concepts-importer-with-integrated-bus-simulation]]
+==== Importer with integrated Bus Simulation [[common-concepts-importer-with-integrated-bus-simulation]]
 In the third variant of the communication architecture, the bus simulation is built directly into the respective importer.
 The supported bus features are analogous to the <<common-concepts-composition-with-dedicated-bus-simulation-fmu, Composition with dedicated Bus Simulation FMU>> use case.
 The corresponding limitations regarding the behavior of the bus simulation are importer-specific.


### PR DESCRIPTION
"Importer with Integrated Bus Simulation" should be changed to "Importer with integrated Bus Simulation" to homogenization of the system composition names as also done in other system composition names (e.g. "Composition with dedicated Bus Simulation FMU")