### PR TITLE
Typo in LowCut Terminals Example

### DIFF
--- a/docs/examples/X_network4FMI_terminalsAndIcons_lowCut.xml
+++ b/docs/examples/X_network4FMI_terminalsAndIcons_lowCut.xml
@@ -11,7 +11,7 @@
         variableName="Powertrain.Tx_Clock" memberName="Tx_Clock" />
       <TerminalMemberVariable variableKind="signal"
         variableName="Powertrain.Tx_Data" memberName="Tx_Data" />
-      <Terminal terminalKind="org.fmi-ls-bus.configuration" name="Configuration" matchingRule="bus">
+      <Terminal terminalKind="org.fmi-ls-bus.network-terminal.configuration" name="Configuration" matchingRule="bus">
         <TerminalMemberVariable variableKind="signal"
           variableName="BusNotification" memberName="BusNotification" />
       </Terminal>


### PR DESCRIPTION
With regards to the Configuration Terminal, section 5.4.1.1 says "terminalKind must be **org.fmi-ls-bus.network-terminal.configuration**."