### PR TITLE
Add missing parentheses in macro

### DIFF
--- a/headers/fmi3LsBusUtilEthernet.h
+++ b/headers/fmi3LsBusUtilEthernet.h
@@ -185,7 +185,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             + sizeof(fmi3LsBusEthernetConfigParameterType)                                                         \
             + sizeof(fmi3LsBusEthernetMdiMode)                                                                     \
             + sizeof(fmi3LsBusEthernetPhyTypeLength)                                                               \
-            + SupportedPhyTypesLength;                                                                             \
+            + (SupportedPhyTypesLength);                                                                           \
                                                                                                                    \
         _op.parameterType = FMI3_LS_BUS_ETHERNET_CONFIG_PARAMETER_TYPE_SUPPORTED_PHY_TYPES;                        \
         _op.supportedPhyTypes.mdiMode = MdiMode;                                                                   \


### PR DESCRIPTION
The macro `FMI3_LS_BUS_ETHERNET_CREATE_OP_CONFIGURATION_SUPPORTED_PHY_TYPES` lacks parentheses around the SupportedPhyTypesLength parameter which can lead to problems when invoked in certain ways and triggers a clang-tidy warning.