### PR TITLE
Remove trademark symbol (TM) from PROVEtech:RE tool name

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Additionally, any FMU importer that supports the necessary FMI 3.0 features, suc
 
 |Tool|Type|Features|Remarks
 |---|---|---|---|
-[Akkodis PROVEtech:RE&trade;](https://www.provetech.de/index.php/downloads/provetech-re)|Importer|![Direct Communication](landingpage/DC.svg) ![Bus Simulation FMU](landingpage/BSF.svg) ![Integrated Bus Simulation](landingpage/IBS.svg) <br> ![High-Cut](landingpage/HC.svg) ![Low-Cut: CAN](landingpage/LC_CAN.svg)|Available from PROVEtech:RE 2026
+[Akkodis PROVEtech:RE](https://www.provetech.de/index.php/downloads/provetech-re)|Importer|![Direct Communication](landingpage/DC.svg) ![Bus Simulation FMU](landingpage/BSF.svg) ![Integrated Bus Simulation](landingpage/IBS.svg) <br> ![High-Cut](landingpage/HC.svg) ![Low-Cut: CAN](landingpage/LC_CAN.svg)|Available from PROVEtech:RE 2026
 [Altair Twin Activate](https://www.altair.com/twin-activate/)|Importer|![Direct Communication](landingpage/DC.svg) ![Bus Simulation FMU](landingpage/BSF.svg) <br> ![High-Cut](landingpage/HC.svg) ![Low-Cut: CAN](landingpage/LC_CAN.svg) ![Low-Cut: FlexRay](landingpage/LC_FR.svg)|Fmi3-Terminals are not supported
 [AVL Model.CONNECT&trade;](https://www.avl.com/de-at/simulation-solutions/software-offering/simulation-tools-a-z/modelconnect)|Importer|![Direct Communication](landingpage/DC.svg) ![Bus Simulation FMU](landingpage/BSF.svg) <br> ![High-Cut](landingpage/HC.svg) ![Low-Cut: CAN](landingpage/LC_CAN.svg) ![Low-Cut: FlexRay](landingpage/LC_FR.svg)|-
 [dSPACE SystemDesk](https://www.dspace.com/en/pub/home/products/sw/system_architecture_software/systemdesk.cfm)|Exporter|![Low-Cut: CAN](landingpage/LC_CAN.svg) ![Low-Cut: FlexRay](landingpage/LC_FR.svg)|Available since RLS 2024-B


### PR DESCRIPTION
Remove trademark symbol (TM) from PROVEtech:RE tool name. It was a copy-paste issue