### PR TITLE
Adding a note to the specification and fixing CAN header when using CAN Remote Transmission Request frames

### DIFF
--- a/docs/4_4_1_can.adoc
+++ b/docs/4_4_1_can.adoc
@@ -199,11 +199,11 @@ For specification, the boolean values `TRUE` and `FALSE` (see <<table-boolean-va
 |1 byte 
 |Specifies whether the given frame represents a Remote Transmission Request frame.
 For specification, the boolean values `TRUE` and `FALSE` (see <<table-boolean-value-kinds>>) shall be used.
-Note: If Rtr = `TRUE`, the Data argument of the <<low-cut-can-transmit-operation, `CAN Transmit`>> operation does not contain any data. In this case the Data Length argument may be set to any value within the admissible range and describes the number of data bytes that the requesting node expects. 
+Note: If `Rtr` = `TRUE`, the `Data` argument of the <<low-cut-can-transmit-operation, `CAN Transmit`>> operation does not contain any data. In this case the `Data Length` argument may be set to any value within the admissible range and describes the number of data bytes that the requesting node expects. 
 
 |Data Length 
 |2 bytes 
-|Specifies the length of the Data argument in bytes.
+|Specifies the length of the `Data` argument in bytes.
 Note: The argument value describes the actual data length and not the CAN Data Length Code (DLC).
 
 |Data 

--- a/docs/4_4_1_can.adoc
+++ b/docs/4_4_1_can.adoc
@@ -199,6 +199,7 @@ For specification, the boolean values `TRUE` and `FALSE` (see <<table-boolean-va
 |1 byte 
 |Specifies whether the given frame represents a Remote Transmission Request frame.
 For specification, the boolean values `TRUE` and `FALSE` (see <<table-boolean-value-kinds>>) shall be used.
+Note: If Rtr = `TRUE`, the Data argument of the <<low-cut-can-transmit-operation, `CAN Transmit`>> operation does not contain any data. In this case the Data Length argument may be set to any value within the admissible range and describes the number of data bytes that the requesting node expects. 
 
 |Data Length 
 |2 bytes 

--- a/headers/fmi3LsBusUtilCan.h
+++ b/headers/fmi3LsBusUtilCan.h
@@ -79,10 +79,19 @@ extern "C"
         _op.dataLength = (DataLength);                                                                  \
         if (_op.header.length <= (fmi3UInt32)((BufferInfo)->end - (BufferInfo)->writePos))              \
         {                                                                                               \
-            memcpy((BufferInfo)->writePos, &_op, _op.header.length - (DataLength));                     \
-            (BufferInfo)->writePos += _op.header.length - (DataLength);                                 \
-            memcpy((BufferInfo)->writePos, (Data), (DataLength));                                       \
-            (BufferInfo)->writePos += (DataLength);                                                     \
+            if (FMI3_LS_BUS_FALSE == Rtr)                                                               \
+            {                                                                                           \
+                memcpy((BufferInfo)->writePos, &_op, _op.header.length - (DataLength));                 \
+                (BufferInfo)->writePos += _op.header.length - (DataLength);                             \
+                memcpy((BufferInfo)->writePos, (Data), (DataLength));                                   \
+                (BufferInfo)->writePos += (DataLength);                                                 \
+            }                                                                                           \
+            else                                                                                        \
+            {                                                                                           \
+                memcpy((BufferInfo)->writePos, &_op, _op.header.length);                                \
+                (BufferInfo)->writePos += _op.header.length;                                            \
+            }                                                                                           \
+                                                                                                        \
             (BufferInfo)->status = fmi3True;                                                            \
         }                                                                                               \
         else                                                                                            \

--- a/headers/fmi3LsBusUtilCan.h
+++ b/headers/fmi3LsBusUtilCan.h
@@ -65,13 +65,18 @@ extern "C"
     do                                                                                                  \
     {                                                                                                   \
         fmi3LsBusCanOperationCanTransmit _op;                                                           \
-        _op.header.opCode = FMI3_LS_BUS_CAN_OP_CAN_TRANSMIT;                                              \
+        _op.header.opCode = FMI3_LS_BUS_CAN_OP_CAN_TRANSMIT;                                            \
         _op.header.length = sizeof(fmi3LsBusOperationHeader) +                                          \
                             sizeof(fmi3LsBusCanId) +                                                    \
                             sizeof(fmi3LsBusCanIde) +                                                   \
                             sizeof(fmi3LsBusCanRtr) +                                                   \
-                            sizeof(fmi3LsBusCanDataLength) +                                            \
-                            (DataLength);                                                               \
+                            sizeof(fmi3LsBusCanDataLength);                                             \
+                                                                                                        \
+        if (FMI3_LS_BUS_FALSE == Rtr)                                                                   \
+        {                                                                                               \
+            _op.header.length = _op.header.length + (DataLength)                                        \
+        }                                                                                               \
+                                                                                                        \
         _op.id = (ID);                                                                                  \
         _op.ide = (Ide);                                                                                \
         _op.rtr = (Rtr);                                                                                \

--- a/headers/fmi3LsBusUtilCan.h
+++ b/headers/fmi3LsBusUtilCan.h
@@ -74,7 +74,7 @@ extern "C"
                                                                                                         \
         if (FMI3_LS_BUS_FALSE == Rtr)                                                                   \
         {                                                                                               \
-            _op.header.length = _op.header.length + (DataLength)                                        \
+            _op.header.length = _op.header.length + (DataLength);                                       \
         }                                                                                               \
                                                                                                         \
         _op.id = (ID);                                                                                  \

--- a/tests/helper/src/fmi_3_ls_bus_header_test_helper_can.cpp
+++ b/tests/helper/src/fmi_3_ls_bus_header_test_helper_can.cpp
@@ -40,9 +40,13 @@ void CheckCanTransmitOperation(long long int id, int ide, int rtr, size_t dataSi
 	EXPECT_EQ(operation->ide, ide * multiplier);
 	EXPECT_EQ(operation->rtr, rtr * multiplier);
 	EXPECT_EQ(operation->dataLength, dataSize);
-	for (size_t i = 0; i < dataSize; i++)
+
+	if (0 == rtr)
 	{
-		EXPECT_EQ(operation->data[i], data[i]);
+		for (size_t i = 0; i < dataSize; i++)
+		{
+			EXPECT_EQ(operation->data[i], data[i]);
+		}
 	}
 }
 

--- a/tests/test/fmi_3_ls_bus_header_tests_can.cpp
+++ b/tests/test/fmi_3_ls_bus_header_tests_can.cpp
@@ -1083,9 +1083,13 @@ TEST(Fmi3LsBusCombinationTest, maxValues) {
 	EXPECT_EQ(canTransmitOperation->ide, UINT8_MAX);
 	EXPECT_EQ(canTransmitOperation->rtr, UINT8_MAX);
 	EXPECT_EQ(canTransmitOperation->dataLength, sizeof(data));
-	for (size_t i = 0; i < sizeof(data); i++)
+	
+	if (0 != canTransmitOperation->rtr)
 	{
-		EXPECT_EQ(canTransmitOperation->data[i], data[i]);
+		for (size_t i = 0; i < sizeof(data); i++)
+		{
+			EXPECT_EQ(canTransmitOperation->data[i], data[i]);
+		}
 	}
 
 	FMI3_LS_BUS_READ_NEXT_OPERATION(&secondBufferInfo, operationHeader);
@@ -1159,9 +1163,13 @@ TEST(Fmi3LsBusCombinationTest, maxValues) {
 	EXPECT_EQ(canTransmitOperation->ide, UINT8_MAX);
 	EXPECT_EQ(canTransmitOperation->rtr, UINT8_MAX);
 	EXPECT_EQ(canTransmitOperation->dataLength, sizeof(data));
-	for (size_t i = 0; i < sizeof(data); i++)
+		
+	if (0 != canTransmitOperation->rtr)
 	{
-		EXPECT_EQ(canTransmitOperation->data[i], data[i]);
+		for (size_t i = 0; i < sizeof(data); i++)
+		{
+			EXPECT_EQ(canTransmitOperation->data[i], data[i]);
+		}
 	}
 }
 
@@ -1216,9 +1224,13 @@ TEST(Fmi3LsBusCombinationTest, maxAndWrongValues) {
 	EXPECT_EQ(canTransmitOperation->ide, 0);
 	EXPECT_EQ(canTransmitOperation->rtr, 0);
 	EXPECT_EQ(canTransmitOperation->dataLength, sizeof(data));
-	for (size_t i = 0; i < sizeof(data); i++)
+
+	if (0 != canTransmitOperation->rtr)
 	{
-		EXPECT_EQ(canTransmitOperation->data[i], data[i]);
+		for (size_t i = 0; i < sizeof(data); i++)
+		{
+			EXPECT_EQ(canTransmitOperation->data[i], data[i]);
+		}
 	}
 
 	FMI3_LS_BUS_READ_NEXT_OPERATION(&secondBufferInfo, operationHeader);
@@ -1291,9 +1303,13 @@ TEST(Fmi3LsBusCombinationTest, maxAndWrongValues) {
 	EXPECT_EQ(canTransmitOperation->ide, 0);
 	EXPECT_EQ(canTransmitOperation->rtr, 0);
 	EXPECT_EQ(canTransmitOperation->dataLength, sizeof(data));
-	for (size_t i = 0; i < sizeof(data); i++)
+
+	if (0 != canTransmitOperation->rtr)
 	{
-		EXPECT_EQ(canTransmitOperation->data[i], data[i]);
+		for (size_t i = 0; i < sizeof(data); i++)
+		{
+			EXPECT_EQ(canTransmitOperation->data[i], data[i]);
+		}
 	}
 }
 

--- a/tests/test/fmi_3_ls_bus_header_tests_can.cpp
+++ b/tests/test/fmi_3_ls_bus_header_tests_can.cpp
@@ -1209,11 +1209,6 @@ TEST(Fmi3LsBusCombinationTest, maxAndWrongValues) {
 	EXPECT_EQ(canTransmitOperation->rtr, 0);
 	EXPECT_EQ(canTransmitOperation->dataLength, sizeof(data));
 
-	for (size_t i = 0; i < sizeof(data); i++)
-	{
-		EXPECT_EQ(canTransmitOperation->data[i], data[i]);
-	}
-
 	FMI3_LS_BUS_READ_NEXT_OPERATION(&secondBufferInfo, operationHeader);
 	canFdTransmitOperation = (fmi3LsBusCanOperationCanFdTransmit*)operationHeader;
 	EXPECT_EQ(canFdTransmitOperation->id, UINT32_MAX);
@@ -1284,11 +1279,6 @@ TEST(Fmi3LsBusCombinationTest, maxAndWrongValues) {
 	EXPECT_EQ(canTransmitOperation->ide, 0);
 	EXPECT_EQ(canTransmitOperation->rtr, 0);
 	EXPECT_EQ(canTransmitOperation->dataLength, sizeof(data));
-
-	for (size_t i = 0; i < sizeof(data); i++)
-	{
-		EXPECT_EQ(canTransmitOperation->data[i], data[i]);
-	}
 }
 
 /**

--- a/tests/test/fmi_3_ls_bus_header_tests_can.cpp
+++ b/tests/test/fmi_3_ls_bus_header_tests_can.cpp
@@ -1083,14 +1083,6 @@ TEST(Fmi3LsBusCombinationTest, maxValues) {
 	EXPECT_EQ(canTransmitOperation->ide, UINT8_MAX);
 	EXPECT_EQ(canTransmitOperation->rtr, UINT8_MAX);
 	EXPECT_EQ(canTransmitOperation->dataLength, sizeof(data));
-	
-	if (0 != canTransmitOperation->rtr)
-	{
-		for (size_t i = 0; i < sizeof(data); i++)
-		{
-			EXPECT_EQ(canTransmitOperation->data[i], data[i]);
-		}
-	}
 
 	FMI3_LS_BUS_READ_NEXT_OPERATION(&secondBufferInfo, operationHeader);
 	canFdTransmitOperation = (fmi3LsBusCanOperationCanFdTransmit*)operationHeader;
@@ -1163,14 +1155,6 @@ TEST(Fmi3LsBusCombinationTest, maxValues) {
 	EXPECT_EQ(canTransmitOperation->ide, UINT8_MAX);
 	EXPECT_EQ(canTransmitOperation->rtr, UINT8_MAX);
 	EXPECT_EQ(canTransmitOperation->dataLength, sizeof(data));
-		
-	if (0 != canTransmitOperation->rtr)
-	{
-		for (size_t i = 0; i < sizeof(data); i++)
-		{
-			EXPECT_EQ(canTransmitOperation->data[i], data[i]);
-		}
-	}
 }
 
 /**
@@ -1224,14 +1208,6 @@ TEST(Fmi3LsBusCombinationTest, maxAndWrongValues) {
 	EXPECT_EQ(canTransmitOperation->ide, 0);
 	EXPECT_EQ(canTransmitOperation->rtr, 0);
 	EXPECT_EQ(canTransmitOperation->dataLength, sizeof(data));
-
-	if (0 != canTransmitOperation->rtr)
-	{
-		for (size_t i = 0; i < sizeof(data); i++)
-		{
-			EXPECT_EQ(canTransmitOperation->data[i], data[i]);
-		}
-	}
 
 	FMI3_LS_BUS_READ_NEXT_OPERATION(&secondBufferInfo, operationHeader);
 	canFdTransmitOperation = (fmi3LsBusCanOperationCanFdTransmit*)operationHeader;
@@ -1304,12 +1280,9 @@ TEST(Fmi3LsBusCombinationTest, maxAndWrongValues) {
 	EXPECT_EQ(canTransmitOperation->rtr, 0);
 	EXPECT_EQ(canTransmitOperation->dataLength, sizeof(data));
 
-	if (0 != canTransmitOperation->rtr)
+	for (size_t i = 0; i < sizeof(data); i++)
 	{
-		for (size_t i = 0; i < sizeof(data); i++)
-		{
-			EXPECT_EQ(canTransmitOperation->data[i], data[i]);
-		}
+		EXPECT_EQ(canTransmitOperation->data[i], data[i]);
 	}
 }
 

--- a/tests/test/fmi_3_ls_bus_header_tests_can.cpp
+++ b/tests/test/fmi_3_ls_bus_header_tests_can.cpp
@@ -1209,6 +1209,11 @@ TEST(Fmi3LsBusCombinationTest, maxAndWrongValues) {
 	EXPECT_EQ(canTransmitOperation->rtr, 0);
 	EXPECT_EQ(canTransmitOperation->dataLength, sizeof(data));
 
+	for (size_t i = 0; i < sizeof(data); i++)
+	{
+		EXPECT_EQ(canTransmitOperation->data[i], data[i]);
+	}
+
 	FMI3_LS_BUS_READ_NEXT_OPERATION(&secondBufferInfo, operationHeader);
 	canFdTransmitOperation = (fmi3LsBusCanOperationCanFdTransmit*)operationHeader;
 	EXPECT_EQ(canFdTransmitOperation->id, UINT32_MAX);


### PR DESCRIPTION
Adding a note to the specification and correction of the CAN util header (fmi3LsBusUtilCan.h) when using CAN Remote Transmission Request Frames, once the Data Length argument is set to a value but the Data argument of the CAN Transmit operation has a length of 0.